### PR TITLE
Refactor/target framework

### DIFF
--- a/MPesa/Internal/InternalClient.cs
+++ b/MPesa/Internal/InternalClient.cs
@@ -1,9 +1,5 @@
 using System;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 using MPesa.helpers;
 using MPesa.security;

--- a/MPesa/MPesa.csproj
+++ b/MPesa/MPesa.csproj
@@ -12,6 +12,7 @@
         <RepositoryUrl>https://github.com/paymentsds/mpesa-csharp-sdk</RepositoryUrl>
         <Version>0.1.0</Version>
         <WebPage>paymentsds.org</WebPage>
+        <PackageVersion>1.0.0</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MPesa/MPesa.csproj
+++ b/MPesa/MPesa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Paymentsds.Sdk.MPesaSdk</PackageId>
         <Title>Paymentsds MPesa-csharp-sdk</Title>
         <Authors>Delfim Uqueio, Eurico Mazivila, Jose Machanguele, Jossias Mupandza</Authors>
@@ -17,6 +17,7 @@
     <ItemGroup>
       <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
       <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+      <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
 </Project>

--- a/MPesa/helpers/HttpClientHelper.cs
+++ b/MPesa/helpers/HttpClientHelper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Web;
 using MPesa.Internal;
 
 namespace MPesa.helpers


### PR DESCRIPTION
In this pull request, I changed the target framework of the class library for .netstandard2.0 and the package version for 1.0.0. Allowing with this change the compatibility of the sdk with other versions of .NET, that is, it will now be possible to use the sdk in .NET Framework and .NET Core projects.

More information of .NET Standard: https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0 
